### PR TITLE
Enable Codecov PR comments and status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: 'reach, diff, flags, files'
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
Adds `codecov.yml` so Codecov posts a PR coverage comment and project/patch status checks (`target: auto`, 1% threshold).

Needs the Codecov app installed and `CODECOV_TOKEN` set (already referenced in CI).
