### PR TITLE
Mark django-tree as production-ready, leaving beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ scaling limit, and changes the type of `path.value` (see Upgrading below).
   key strictly between its two neighbours. There is no longer a periodic
   full-renumber of siblings (the old `#17` gap-exhaustion rebuild is gone), so
   inserts stay cheap no matter how many siblings already exist.
+- No longer beta: django-tree is now considered production-ready.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Fast and easy tree structures for Django, maintained inside the database.
 
 [![](https://img.shields.io/pypi/v/django-tree.svg?style=flat-square)](https://pypi.python.org/pypi/django-tree) [![](https://img.shields.io/github/actions/workflow/status/BertrandBordage/django-tree/ci.yml?branch=master&style=flat-square)](https://github.com/BertrandBordage/django-tree/actions/workflows/ci.yml) [![](https://img.shields.io/codecov/c/github/BertrandBordage/django-tree/master.svg?style=flat-square)](https://codecov.io/gh/BertrandBordage/django-tree)
 
-> [!WARNING]
-> In beta — not production-ready yet.
-
 django-tree solves the same problem as **django-treebeard**,
 **django-tree-queries**, **django-mptt** and **django-treenode**: storing and
 querying tree (hierarchy) structures with Django. It does it differently: you add a `PathField` to an ordinary model
@@ -55,7 +52,7 @@ Python on the ORM save cycle (`save()`, `delete()`, `QuerySet.update()`,
 | **Tree filters as composable ORM lookups** | ✅ `__descendant_of`, `__child_of` | 🟡 manager methods | 🟡 manager methods | 🟡 manager methods | 🟡 manager methods | 🟡 `with_tree_fields()` | 🟡 cached properties |
 | **Admin integration** | ❌ form field only | ✅ drag-and-drop | ✅ drag-and-drop | ✅ drag-and-drop | ✅ drag-and-drop | ✅ cut/paste | ✅ |
 | **Template tags to render trees** | ❌ | 🟡 | 🟡 | 🟡 | ✅ `{% recursetree %}` | ✅ `{% recursetree %}` | 🟡 |
-| **Production-ready** | ❌ beta | ✅ | ✅ | ✅ | 🟡 works, unmaintained | ✅ | ✅ |
+| **Production-ready** | ✅ | ✅ | ✅ | ✅ | 🟡 works, unmaintained | ✅ | ✅ |
 
 ✅ yes / good · 🟡 partial or depends on the variant · ❌ no / poor.
 
@@ -88,7 +85,7 @@ In short:
 
 - **django-tree** keeps the tree correct in the database itself, so on
   PostgreSQL bulk operations, `update()` and raw SQL stay safe, with balanced
-  reads and writes — at the cost of being still beta and without admin
+  reads and writes — at the cost of being without admin
   drag-and-drop or tree-rendering template tags yet. On SQLite and MySQL the
   path is maintained in Python on the ORM save cycle instead (raw SQL then needs
   a manual rebuild).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 license = "BSD-2-Clause"
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Framework :: Django",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",


### PR DESCRIPTION
Drops the beta status now that the project is mature.

- pyproject: `Development Status :: 5 - Production/Stable`
- README: remove beta warning, flip Production-ready cell, drop "still beta" wording
- CHANGELOG: note leaving beta