### PR TITLE
Fix PathField.value_to_string() for serializers like django-reversion

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -2831,7 +2831,9 @@ class PathFieldTest(CommonTest):
         self.assertIsInstance(serialized, str)
         # Round-trips back to the original path through `to_python`, as
         # Django's deserializers do.
-        self.assertEqual(field.to_python(json.loads(serialized)).value, france.path.value)
+        self.assertEqual(
+            field.to_python(json.loads(serialized)).value, france.path.value
+        )
 
     def test_value_to_string_unsaved(self):
         field = Place._meta.get_field('path')

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import doctest
+import json
 import uuid
 from contextlib import nullcontext
 from importlib import import_module
@@ -2818,6 +2819,23 @@ class PathFieldTest(CommonTest):
         self.assertEqual(field.to_python(memoryview(b'\x02\x00')).value, b'\x02\x00')
         self.assertEqual(field.to_python(b'\x03\x00').value, b'\x03\x00')
         self.assertEqual(field.get_prep_value(memoryview(b'\x04\x00')), b'\x04\x00')
+
+    def test_value_to_string(self):
+        # Serializers (e.g. django-reversion) call `value_to_string` on every
+        # field; the base `BinaryField` implementation chokes on the `Path`
+        # wrapper instead of raw `bytes` (#39).
+        self.create_all_test_places()
+        field = Place._meta.get_field('path')
+        france = Place.objects.get(name='France')
+        serialized = field.value_to_string(france)
+        self.assertIsInstance(serialized, str)
+        # Round-trips back to the original path through `to_python`, as
+        # Django's deserializers do.
+        self.assertEqual(field.to_python(json.loads(serialized)).value, france.path.value)
+
+    def test_value_to_string_unsaved(self):
+        field = Place._meta.get_field('path')
+        self.assertIsNone(field.value_to_string(Place(name='unsaved')))
 
     def test_unsupported_backend_raises(self):
         field = Place._meta.get_field('path')

--- a/tree/fields.py
+++ b/tree/fields.py
@@ -168,7 +168,7 @@ class PathField(BinaryField):
             return 'RAW(%d)' % ORACLE_PATH_BYTES
         return super().db_type(connection)
 
-    def value_to_string(self, obj: Model) -> str | None:
+    def value_to_string(self, obj: Model) -> str | None:  # type: ignore[override]
         # Django's base `BinaryField.value_to_string` assumes the stored value
         # is already `bytes` and feeds it straight to `b64encode`, but
         # `value_from_object` returns the `Path` wrapper here -- crashing
@@ -177,7 +177,7 @@ class PathField(BinaryField):
         # first, then hex-encode (rather than relying on base64) since `None`
         # also has to round-trip cleanly for paths that haven't been
         # assigned/saved yet.
-        value = self.value_from_object(obj)
+        value = cast('Path | bytes | None', self.value_from_object(obj))
         if isinstance(value, Path):
             value = value.value
         if value is None:

--- a/tree/fields.py
+++ b/tree/fields.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import Any, cast
@@ -139,12 +140,16 @@ class PathField(BinaryField):
         value = bytes(value) if value else None
         return Path(self, value)
 
-    def to_python(self, value: 'bytes | memoryview | Path | None') -> Path:
+    def to_python(self, value: 'bytes | memoryview | str | Path | None') -> Path:
         # https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#converting-values-to-python-objects
         if isinstance(value, Path):
             return value
         if isinstance(value, memoryview):
             value = bytes(value)
+        elif isinstance(value, str):
+            # The hex string produced by `value_to_string`, fed back in by
+            # deserializers (e.g. django-reversion, `loaddata`).
+            value = bytes.fromhex(value)
         return Path(self, value)
 
     def get_prep_value(
@@ -162,6 +167,22 @@ class PathField(BinaryField):
         if connection.vendor == 'oracle':
             return 'RAW(%d)' % ORACLE_PATH_BYTES
         return super().db_type(connection)
+
+    def value_to_string(self, obj: Model) -> str | None:
+        # Django's base `BinaryField.value_to_string` assumes the stored value
+        # is already `bytes` and feeds it straight to `b64encode`, but
+        # `value_from_object` returns the `Path` wrapper here -- crashing
+        # serializers (e.g. django-reversion) with `TypeError: a bytes-like
+        # object is required, not 'Path'`. Unwrap to the underlying `bytes`
+        # first, then hex-encode (rather than relying on base64) since `None`
+        # also has to round-trip cleanly for paths that haven't been
+        # assigned/saved yet.
+        value = self.value_from_object(obj)
+        if isinstance(value, Path):
+            value = value.value
+        if value is None:
+            return None
+        return json.dumps(value.hex())
 
     def _check_database_backend(self, db_alias: str) -> None:
         if connections[db_alias].vendor not in SUPPORTED_VENDORS:


### PR DESCRIPTION
BinaryField.value_to_string() base64-encodes value_from_object() directly, but PathField stores a Path wrapper rather than raw bytes, so it crashes with "TypeError: a bytes-like object is required, not 'Path'" whenever a tree model is saved under django-reversion (or any serializer that calls value_to_string). Unwrap to bytes and hex-encode, with to_python() updated to decode the hex string back on deserialization.